### PR TITLE
Fix PHP indexer nil pointer dereference

### DIFF
--- a/internal/php/indexer.go
+++ b/internal/php/indexer.go
@@ -320,7 +320,12 @@ func (idx *PHPIndex) GetTypeOfNode(ctx context.Context, node *tree_sitter.Node, 
 		return nil
 	}
 
-	phpCtx := GetPHPContext(ctx)
+	// Get the PHP context safely
+	phpCtx, ok := ctx.Value(PHPContextKey).(*PHPContext)
+	if !ok || phpCtx == nil || phpCtx.InsideClass == nil {
+		// If we don't have the necessary context, return a mixed type
+		return NewMixedType()
+	}
 
 	nodeKind := node.Kind()
 

--- a/internal/php/treesitter.go
+++ b/internal/php/treesitter.go
@@ -36,5 +36,17 @@ func (s *PHPIndex) IsMethodCalledOnClass(ctx context.Context, node *tree_sitter.
 		return false
 	}
 
-	return s.GetTypeOfNode(ctx, current, content).Matches(NewPHPType(className))
+	// Get context information safely - check if PHPContext exists in the context
+	_, ok := ctx.Value(PHPContextKey).(*PHPContext)
+	if !ok {
+		// If we don't have the necessary context, we can't determine the class type
+		return false
+	}
+
+	nodeType := s.GetTypeOfNode(ctx, current, content)
+	if nodeType == nil {
+		return false
+	}
+	
+	return nodeType.Matches(NewPHPType(className))
 }


### PR DESCRIPTION
## Summary
- Fixes a panic caused by nil pointer dereference in PHP indexer during system config completion
- Adds proper nil checks for PHP context and its fields in GetTypeOfNode and IsMethodCalledOnClass methods

## Test plan
- Build and test the LSP
- Load a Shopware project with system config entries

🤖 Generated with [Claude Code](https://claude.ai/code)