### PR TITLE
fix: do not show output on start

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -88,7 +88,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     // Show output channel on start
     outputChannel.appendLine(`Starting Shopware Language Server at ${serverPath}`);
-    outputChannel.show();
 
     // Create and start the client
     client = new LanguageClient(


### PR DESCRIPTION
Its a bit annoying to focus the output channel :sweat_smile: 