### PR TITLE
fix: rename command to avoid conflict with existing shopware.insertSn…

### DIFF
--- a/internal/lsp/codeaction/admin_codeaction.go
+++ b/internal/lsp/codeaction/admin_codeaction.go
@@ -93,7 +93,7 @@ func (p *AdminCodeActionProvider) createAddPropAction(params *protocol.CodeActio
 		Diagnostics: []protocol.Diagnostic{*diag},
 		Command: &protocol.CommandAction{
 			Title:   "Add missing prop",
-			Command: "shopware.insertSnippet",
+			Command: "shopware.editor.insertSnippetAtPosition",
 			Arguments: []interface{}{
 				params.TextDocument.URI,
 				insertPos.Line,

--- a/internal/lsp/codeaction/admin_codeaction_test.go
+++ b/internal/lsp/codeaction/admin_codeaction_test.go
@@ -252,7 +252,7 @@ Component.register('sw-button', {
 
 			// Check the command (used for snippet insertion with cursor positioning)
 			require.NotNil(t, action.Command)
-			assert.Equal(t, "shopware.insertSnippet", action.Command.Command)
+			assert.Equal(t, "shopware.editor.insertSnippetAtPosition", action.Command.Command)
 			require.Len(t, action.Command.Arguments, 4)
 
 			// Arguments: [uri, line, character, snippetText]
@@ -340,7 +340,7 @@ Component.register('mt-card', {
 
 	action := actions[0]
 	require.NotNil(t, action.Command)
-	assert.Equal(t, "shopware.insertSnippet", action.Command.Command)
+	assert.Equal(t, "shopware.editor.insertSnippetAtPosition", action.Command.Command)
 	require.Len(t, action.Command.Arguments, 4)
 
 	// Should use kebab-case in the snippet with cursor placeholder
@@ -445,7 +445,7 @@ Component.register('sw-icon', {
 
 	action := actions[0]
 	require.NotNil(t, action.Command)
-	assert.Equal(t, "shopware.insertSnippet", action.Command.Command)
+	assert.Equal(t, "shopware.editor.insertSnippetAtPosition", action.Command.Command)
 	require.Len(t, action.Command.Arguments, 4)
 
 	// Check that the snippet inserts before /> with cursor placeholder

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -458,8 +458,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     editor.insertSnippet(new vscode.SnippetString(text));
   }));
 
-  // Register generic snippet insertion command (with snippet support for cursor positioning)
-  context.subscriptions.push(vscode.commands.registerCommand('shopware.insertSnippet', async (fileUri: string, line: number, character: number, snippetText: string) => {
+  // Register programmatic snippet insertion command (used by code actions for cursor positioning)
+  context.subscriptions.push(vscode.commands.registerCommand('shopware.editor.insertSnippetAtPosition', async (fileUri: string, line: number, character: number, snippetText: string) => {
     try {
       const document = await vscode.workspace.openTextDocument(vscode.Uri.parse(fileUri));
       const editor = await vscode.window.showTextDocument(document);


### PR DESCRIPTION
…ippet

The shopware.insertSnippet command is already used for the user-facing 'Insert Snippet' action. Renamed the programmatic insertion command to shopware.editor.insertSnippetAtPosition to avoid the conflict.