### PR TITLE
fix(twig): index blocks containing HTML missed by tree-sitter

### DIFF
--- a/internal/twig/parser.go
+++ b/internal/twig/parser.go
@@ -65,19 +65,12 @@ type TwigBlock struct {
 }
 
 // findBlocks recursively traverses the tree to find all blocks.
-// It handles both proper "block" nodes and "ERROR" nodes that occur when
-// the tree-sitter grammar fails to parse blocks containing HTML tags.
+// It only handles proper "block" nodes; blocks that tree-sitter fails to parse
+// (e.g. those containing HTML tags, which produce ERROR nodes) are recovered
+// separately by recoverMissingBlocksFromTags, which captures their full text.
 func findBlocks(node *tree_sitter.Node, content []byte, file *TwigFile) {
 	if node.Kind() == "block" {
 		extractBlockFromNode(node, content, file)
-	} else if node.Kind() == "ERROR" {
-		// Tree-sitter produces ERROR nodes for blocks that contain HTML tags.
-		// These have the structure: ERROR > identifier where the ERROR text
-		// starts with "{% block ".
-		nodeText := string(node.Utf8Text(content))
-		if strings.HasPrefix(strings.TrimSpace(nodeText), "{% block ") {
-			extractBlockFromNode(node, content, file)
-		}
 	}
 
 	// Recursively process all named children

--- a/internal/twig/parser.go
+++ b/internal/twig/parser.go
@@ -11,6 +11,7 @@ import (
 )
 
 var shopwareBlockCommentRegex = regexp.MustCompile(`\{#\s*` + VersionCommentPrefix + `\s*([a-f0-9]+)@([\w\.\-]+)\s*#\}`)
+var twigTagRegex = regexp.MustCompile(`\{%\s*(?:block\s+([A-Za-z0-9_]+)|endblock)\b[^%]*%\}`)
 
 func calculateBlockHash(content string) string {
 	hash := sha256.New()
@@ -63,22 +64,47 @@ type TwigBlock struct {
 	VersionComment *TwigVersionComment
 }
 
-// findBlocks recursively traverses the tree to find all blocks
+// findBlocks recursively traverses the tree to find all blocks.
+// It handles both proper "block" nodes and "ERROR" nodes that occur when
+// the tree-sitter grammar fails to parse blocks containing HTML tags.
 func findBlocks(node *tree_sitter.Node, content []byte, file *TwigFile) {
 	if node.Kind() == "block" {
-		for i := 0; i < int(node.NamedChildCount()); i++ {
-			child := node.NamedChild(uint(i))
-			if child.Kind() == "identifier" {
-				blockName := string(child.Utf8Text(content))
-				blockText := string(node.Utf8Text(content))
-				blockHash := calculateBlockHash(blockText)
+		extractBlockFromNode(node, content, file)
+	} else if node.Kind() == "ERROR" {
+		// Tree-sitter produces ERROR nodes for blocks that contain HTML tags.
+		// These have the structure: ERROR > identifier where the ERROR text
+		// starts with "{% block ".
+		nodeText := string(node.Utf8Text(content))
+		if strings.HasPrefix(strings.TrimSpace(nodeText), "{% block ") {
+			extractBlockFromNode(node, content, file)
+		}
+	}
 
-				var versionComment *TwigVersionComment
-				if prevSibling := findPreviousComment(node, content); prevSibling != nil {
-					commentText := string(prevSibling.Utf8Text(content))
-					versionComment = ParseVersionComment(commentText, int(prevSibling.Range().StartPoint.Row)+1)
-				}
+	// Recursively process all named children
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		findBlocks(node.NamedChild(uint(i)), content, file)
+	}
+}
 
+// extractBlockFromNode extracts block name and metadata from a block or ERROR node.
+// First definition wins: if a block name already exists in file.Blocks, it is not
+// overwritten (e.g., when a nested block reuses a parent's name).
+func extractBlockFromNode(node *tree_sitter.Node, content []byte, file *TwigFile) {
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		child := node.NamedChild(uint(i))
+		if child.Kind() == "identifier" {
+			blockName := string(child.Utf8Text(content))
+			blockText := string(node.Utf8Text(content))
+			blockHash := calculateBlockHash(blockText)
+
+			var versionComment *TwigVersionComment
+			if prevSibling := findPreviousComment(node, content); prevSibling != nil {
+				commentText := string(prevSibling.Utf8Text(content))
+				versionComment = ParseVersionComment(commentText, int(prevSibling.Range().StartPoint.Row)+1)
+			}
+
+			_, exists := file.Blocks[blockName]
+			if !exists {
 				file.Blocks[blockName] = TwigBlock{
 					Name:           blockName,
 					Line:           int(child.Range().StartPoint.Row) + 1,
@@ -86,14 +112,9 @@ func findBlocks(node *tree_sitter.Node, content []byte, file *TwigFile) {
 					Text:           blockText,
 					VersionComment: versionComment,
 				}
-				break
 			}
+			break
 		}
-	}
-
-	// Recursively process all named children
-	for i := 0; i < int(node.NamedChildCount()); i++ {
-		findBlocks(node.NamedChild(uint(i)), content, file)
 	}
 }
 
@@ -141,6 +162,7 @@ func ParseTwig(filePath string, node *tree_sitter.Node, content []byte) (*TwigFi
 	// Find all blocks recursively
 	if bytes.Contains(content, []byte("block")) {
 		findBlocks(node, content, file)
+		recoverMissingBlocksFromTags(content, file)
 	}
 
 	// Find extends tag
@@ -200,4 +222,117 @@ func ParseTwig(filePath string, node *tree_sitter.Node, content []byte) (*TwigFi
 	}
 
 	return file, nil
+}
+
+type blockStartInfo struct {
+	name     string
+	startIdx int
+	line     int
+}
+
+func recoverMissingBlocksFromTags(content []byte, file *TwigFile) {
+	matches := twigTagRegex.FindAllSubmatchIndex(content, -1)
+	if len(matches) == 0 {
+		return
+	}
+
+	stack := make([]blockStartInfo, 0, len(matches))
+	for _, m := range matches {
+		tagStart := m[0]
+		tagEnd := m[1]
+
+		blockNameStart := m[2]
+		blockNameEnd := m[3]
+		if blockNameStart >= 0 && blockNameEnd >= 0 {
+			stack = append(stack, blockStartInfo{
+				name:     string(content[blockNameStart:blockNameEnd]),
+				startIdx: tagStart,
+				line:     lineAtOffset(content, tagStart),
+			})
+			continue
+		}
+
+		// endblock
+		if len(stack) == 0 {
+			continue
+		}
+
+		lastIdx := len(stack) - 1
+		start := stack[lastIdx]
+		stack = stack[:lastIdx]
+
+		if _, exists := file.Blocks[start.name]; exists {
+			continue
+		}
+
+		if start.startIdx < 0 || start.startIdx >= len(content) || tagEnd <= start.startIdx || tagEnd > len(content) {
+			continue
+		}
+
+		blockText := string(content[start.startIdx:tagEnd])
+		blockHash := calculateBlockHash(blockText)
+
+		var versionComment *TwigVersionComment
+		comment := findVersionCommentBeforeOffset(content, start.startIdx)
+		if comment != nil {
+			versionComment = comment
+		}
+
+		file.Blocks[start.name] = TwigBlock{
+			Name:           start.name,
+			Line:           start.line,
+			Hash:           blockHash,
+			Text:           blockText,
+			VersionComment: versionComment,
+		}
+
+	}
+}
+
+func lineAtOffset(content []byte, offset int) int {
+	if offset <= 0 {
+		return 1
+	}
+	if offset > len(content) {
+		offset = len(content)
+	}
+	return bytes.Count(content[:offset], []byte("\n")) + 1
+}
+
+func findVersionCommentBeforeOffset(content []byte, offset int) *TwigVersionComment {
+	if offset <= 0 {
+		return nil
+	}
+	if offset > len(content) {
+		offset = len(content)
+	}
+
+	i := offset - 1
+	for i >= 0 {
+		c := content[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			i--
+			continue
+		}
+		break
+	}
+	if i < 1 || content[i] != '}' || content[i-1] != '#' {
+		return nil
+	}
+
+	commentEnd := i + 1
+	j := i - 2
+	for j >= 1 {
+		if content[j] == '#' && content[j-1] == '{' {
+			commentStart := j - 1
+			commentText := string(content[commentStart:commentEnd])
+			if strings.Contains(commentText, VersionCommentPrefix) {
+				return ParseVersionComment(commentText, lineAtOffset(content, commentStart))
+			}
+			return nil
+		}
+		j--
+	}
+
+	return nil
 }

--- a/internal/twig/parser_test.go
+++ b/internal/twig/parser_test.go
@@ -22,7 +22,7 @@ func TestTwigParse(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "test", file.Path)
-	
+
 	block, exists := file.Blocks["foo"]
 	assert.True(t, exists)
 	assert.Equal(t, "foo", block.Name)
@@ -70,22 +70,71 @@ func TestNestedBlock(t *testing.T) {
 
 	assert.Equal(t, "test", file.Path)
 	assert.Len(t, file.Blocks, 3)
-	
+
 	blockA, existsA := file.Blocks["a"]
 	assert.True(t, existsA)
 	assert.Equal(t, "a", blockA.Name)
 	assert.Equal(t, 2, blockA.Line)
 	assert.NotEmpty(t, blockA.Hash)
-	
+
 	blockB, existsB := file.Blocks["b"]
 	assert.True(t, existsB)
 	assert.Equal(t, "b", blockB.Name)
 	assert.Equal(t, 3, blockB.Line)
-	
+
 	blockC, existsC := file.Blocks["c"]
 	assert.True(t, existsC)
 	assert.Equal(t, "c", blockC.Name)
 	assert.Equal(t, 4, blockC.Line)
+}
+
+func TestBlocksWithHTMLContent(t *testing.T) {
+	tpl := `{% block base_body %}
+    <body>
+        {% block base_header %}
+            <header>
+                {% block base_header_inner %}{% endblock %}
+            </header>
+        {% endblock %}
+
+        {% block base_content %}
+            <div class="content">
+                content here
+            </div>
+        {% endblock %}
+    </body>
+{% endblock %}`
+
+	parser := tree_sitter.NewParser()
+	assert.NoError(t, parser.SetLanguage(tree_sitter.NewLanguage(tree_sitter_twig.Language())))
+	defer parser.Close()
+
+	tree := parser.Parse([]byte(tpl), nil)
+	defer tree.Close()
+
+	file, err := ParseTwig("test", tree.RootNode(), []byte(tpl))
+	assert.NoError(t, err)
+
+	// base_body: tree-sitter produces ERROR node due to HTML, but parser should still find it
+	blockBody, existsBody := file.Blocks["base_body"]
+	assert.True(t, existsBody, "Should find base_body block even with HTML content (ERROR node)")
+	assert.Equal(t, "base_body", blockBody.Name)
+	assert.Equal(t, 1, blockBody.Line)
+
+	// base_header: parsed as a proper block node
+	blockHeader, existsHeader := file.Blocks["base_header"]
+	assert.True(t, existsHeader, "Should find base_header block")
+	assert.Equal(t, "base_header", blockHeader.Name)
+
+	// base_header_inner: simple block without HTML
+	blockInner, existsInner := file.Blocks["base_header_inner"]
+	assert.True(t, existsInner, "Should find base_header_inner block")
+	assert.Equal(t, "base_header_inner", blockInner.Name)
+
+	// base_content: tree-sitter produces ERROR node due to HTML
+	blockContent, existsContent := file.Blocks["base_content"]
+	assert.True(t, existsContent, "Should find base_content block even with HTML content (ERROR node)")
+	assert.Equal(t, "base_content", blockContent.Name)
 }
 
 func TestBlockWithVersionComment(t *testing.T) {


### PR DESCRIPTION
# fix(twig): index blocks containing HTML missed by tree-sitter

## Problem

tree-sitter's Twig grammar emits `ERROR` nodes for `{% block %}` bodies that
contain raw HTML. Because the indexer only walked proper `block` nodes, some
blocks were silently dropped from the block index. That broke **Go to Parent
Block** in VS Code for those blocks — extending the block from the original
template still worked; only navigation back to the parent definition did not.

Before the fix:
<img width="1356" height="524" alt="image" src="https://github.com/user-attachments/assets/3ac540b9-401f-4f10-acd0-c68cb3e8419b" />

After the fix:
<img width="1342" height="521" alt="image" src="https://github.com/user-attachments/assets/e7efc31b-3fab-4c8e-9eb6-8e275f3d0719" />


## Real-world example

`buy-widget.html.twig` defines:

```twig
{% block buy_widget_delivery_informations %}
    <div class="product-availability">
        {% if (product.stock > 0 and product.isCloseout == true) or product.isCloseout == false %}
            <span class="product-availability-available">
                {{ 'listing.boxAvailabilityAvailable'|trans }}
            </span>
        {% else %}
            <span class="product-availability-unavailable">
                {{ 'listing.boxAvailabilityUnavailable'|trans }}
            </span>
        {% endif %}
    </div>
{% endblock %}
```

**Before this fix:** Go to Parent Block on `buy_widget_delivery_informations`
in VS Code returned nothing — the block was missing from the index because its
HTML body parsed into an `ERROR` node. Extending that block from the parent
template was unaffected.

**After this fix:** the block is indexed and Go to Parent Block resolves
correctly in VS Code.

## Why some HTML blocks worked and others didn't

The bug looked inconsistent in VS Code: Go to Parent Block worked for some
blocks containing HTML but not others. The deciding factor is not "contains
HTML" — it's **what the block body starts with**.

`buy_widget_ordernumber_container` starts with Twig tags (`{% set %}`, then
`{% if %}`) and only has its `<div>` nested inside the `if`. tree-sitter parses
the block construct successfully; the raw HTML error is isolated into `ERROR`
nodes deep in the subtree, while the ancestor `block` node stays intact:

```
block [0:0-7:14]          ← real block node, found by the indexer ✓
    ERROR [3:8-4:12]      ← <div> error buried deep inside the {% if %}
    ERROR [5:8-6:4]
```

`buy_widget_delivery_informations` starts immediately with raw HTML
(`<div class="product-availability">`). tree-sitter can't attach raw text as the
block's leading content, so recovery triggers at the `{% block %}` tag itself —
the opening tag is swallowed into an `ERROR` node and **no `block` node is ever
created**:

```
ERROR [0:0-0:44]                       ← the {% block %} tag itself ✗
tag [4:0-4:14] = "{% endblock %}"
```

The old `findBlocks` only walked named `block` nodes, so the first case was
indexed and the second was dropped.

## Solution

- `findBlocks` keeps walking only proper `block` nodes; extraction logic is
  shared via a new `extractBlockFromNode` helper.
- A regex recovery pass (`recoverMissingBlocksFromTags`) runs after the AST
  walk. It scans the raw source for `{% block %}` / `{% endblock %}` tags,
  matches them with a stack, and indexes any block the AST walk missed —
  capturing the **full block body** from the opening tag through `{% endblock %}`.
- First-definition-wins, so AST results take precedence and nested
  re-declarations don't overwrite the outer block; recovery only fills gaps.

### Why recovery owns the HTML blocks (and `ERROR` extraction does not)

An earlier iteration extracted blocks directly from `ERROR` nodes inside
`findBlocks`. That was dropped: an `ERROR` node for an HTML block spans only the
opening `{% block X %}` tag, so the extracted text — and therefore the block
**hash** — covered just the opening tag, not the body. Because of
first-definition-wins, that truncated entry also shadowed the correct full-text
recovery. Since the block hash drives upstream **staleness detection** (the
"upstream block has been changed" diagnostic / code action), a truncated hash
meant body changes never altered the hash and staleness detection silently
failed. Letting `recoverMissingBlocksFromTags` own these blocks records their
complete text, so the hash reflects the whole body.

## Testing

- New unit test `TestBlocksWithHTMLContent` covering blocks with HTML bodies
  (asserts the blocks are indexed with the right name and line).
- `go test -race ./internal/...` — passes.
- `golangci-lint run` — 0 issues.
- Verified manually in VS Code against test project: Go to Parent Block on
  `buy_widget_delivery_informations` now works; block extension from the parent
  template still works as before.
